### PR TITLE
fix app being unable to start because the create_temp_dr()

### DIFF
--- a/src/fs/temp_dir.rs
+++ b/src/fs/temp_dir.rs
@@ -1,12 +1,16 @@
 use std::{
     env,
+    path::Path,
     fs::{create_dir, remove_dir_all},
 };
 
 pub fn create_temp_dir() {
     let tmp = env::temp_dir();
     let vizer_temp = format!("{}/vizer", tmp.display());
-    create_dir(vizer_temp).expect("Couldn't create the temporary directory!");
+    if !Path::new(&vizer_temp).exists()
+    {
+        create_dir(vizer_temp).expect("Couldn't create the temporary directory!");
+    }
 }
 
 pub fn remove_temp_dir() {


### PR DESCRIPTION
fix the problem explained in [issue #7](https://github.com/anotherlusitano/vizer-cli/issues/7).

this code fix the issue by checking if the folder already exist with the [std::path;](https://doc.rust-lang.org/std/path/struct.Path.html#method.exists) crate  and if it already exist prevent the code to create the folder again.