### PR TITLE
add version flag, and fix clippy warn

### DIFF
--- a/src/cli/choose_with_images.rs
+++ b/src/cli/choose_with_images.rs
@@ -16,7 +16,7 @@ const MAX_OPTIONS: usize = 25;
 const COLOR: Color = Color::Yellow;
 
 pub fn choose_with_images(
-    options: &Vec<String>,
+    options: &[String],
     imgs_path: Vec<String>,
     is_to_choose_media: bool,
 ) -> Result<usize, ()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ static USE_MPV: OnceLock<bool> = OnceLock::new();
 fn main() {
     let matches = Command::new("vizer-cli")
         .about("CLI tool to watch movies/series/animes in portuguese")
+        .version(env!("CARGO_PKG_VERSION"))
         .subcommand_required(true)
         .arg_required_else_help(true)
         .arg(

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,3 +1,3 @@
-pub mod vlc;
 pub mod mpv;
+pub mod vlc;
 pub mod watch_media;


### PR DESCRIPTION
this closes [#18](https://github.com/anotherlusitano/vizer-cli/issues/18)

the change in "src/cli/choose_with_images.rs" is a fix for one "cargo clippy" warning. 
and the change in "src/player/mod.rs" is a change made by "cargo fmt".

(this change above was made because is said to in the "Contributing" tab in the "README.md" file, in the step 4 "Use cargo fmt and fix all clippy warnings")