### PR TITLE
Update crate selthi to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,9 +1424,9 @@ dependencies = [
 
 [[package]]
 name = "selthi"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ecbae036e15d3b55dfe2da54c1aa967605f6e56051ea2ed374e6d122b9dccc"
+checksum = "7b369f6a493df8cdd64fe424585bc87c0b2755bf680f78979688915c297e40c5"
 dependencies = [
  "crossterm",
  "ueberzug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ clap = "4.4.4"
 thirtyfour = "0.31.0"
 tokio = "1.32.0"
 futures = "0.3.30"
-selthi = { version = "0.2.3", features = ["with_images"] }
+selthi = { version = "0.2.4", features = ["with_images"] }


### PR DESCRIPTION
This update is necessary so that the user can type UTF-8 characters when choosing the “search” option in the menu.