### PR TITLE
prevent edge case of web driver port already being used

### DIFF
--- a/src/driver/start_driver.rs
+++ b/src/driver/start_driver.rs
@@ -8,6 +8,11 @@ use thirtyfour::{DesiredCapabilities, WebDriver};
 
 use crate::USE_GECKODRIVER;
 
+fn kill_browser_driver(driver_command: &str) {
+    let mut child = Command::new("pkill").arg(driver_command).spawn().unwrap();
+    child.kill().unwrap();
+}
+
 pub async fn get_driver() -> WebDriver {
     let use_geckodriver = USE_GECKODRIVER.get().unwrap();
 
@@ -31,6 +36,8 @@ pub fn start_browser_driver() -> Child {
     } else {
         "chromedriver"
     };
+
+    kill_browser_driver(driver_command);
 
     let browser_driver = Command::new(driver_command)
         .stdout(Stdio::null())


### PR DESCRIPTION
this is important!, if the app be forced to stop by the user or receive one unwrap() error the web driver won't be closed, causing a memory leak

this is not the fix for the memory leak itself, it just kills the web driver that was open in the last time the app was executed,
and consequently closing the opened door

OBS :
chromedriver is able to bypass the port already being used and still work, but the same can't be said do geckodriver, 
geckodriver won't work if the port is already in use


i was studying this project and i manage to solve the memory leak by creating a function quit() and using the error handler to send all app errors to execute de quit() function, and in the quit() function the webdriver was killed.

i won't commit it here because, i changed ALOT of the code (not necessarily for the better) to learn and try something new, and the method that i used  is certain not the most efficient way of solving this issue (AKA my code is bad).

how i changed it : [fork study branch](https://github.com/HaruNashii/vizer-cli-fork/tree/rewrite-to-learn)