### PR TITLE
Fix geckodriver crashing the app

### DIFF
--- a/src/driver/start_driver.rs
+++ b/src/driver/start_driver.rs
@@ -46,6 +46,7 @@ pub fn start_browser_driver() -> Child {
 
     let browser_driver = Command::new(driver_command)
         .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .unwrap();
 

--- a/src/player/watch_media.rs
+++ b/src/player/watch_media.rs
@@ -97,7 +97,7 @@ pub async fn watch_media(media: Media, img_mode: bool) -> Result<(), CmdError> {
             Ok("replay") => play_video(&video_url),
             Ok("quit") => break,
             Ok("next") => {
-                driver.back().await?;
+                driver.goto(&url).await?;
 
                 seasons = parse_seasons(&driver).await?;
 
@@ -123,7 +123,7 @@ pub async fn watch_media(media: Media, img_mode: bool) -> Result<(), CmdError> {
                 play_video(&video_url);
             }
             Ok("previous") => {
-                driver.back().await?;
+                driver.goto(&url).await?;
 
                 seasons = parse_seasons(&driver).await?;
 
@@ -149,7 +149,7 @@ pub async fn watch_media(media: Media, img_mode: bool) -> Result<(), CmdError> {
                 play_video(&video_url);
             }
             Ok("select episode") => {
-                driver.back().await?;
+                driver.goto(&url).await?;
 
                 seasons = parse_seasons(&driver).await?;
 
@@ -187,7 +187,7 @@ pub async fn watch_media(media: Media, img_mode: bool) -> Result<(), CmdError> {
                 play_video(&video_url);
             }
             Ok("select season") => {
-                driver.back().await?;
+                driver.goto(&url).await?;
 
                 seasons = parse_seasons(&driver).await?;
 


### PR DESCRIPTION
This PR is intended to solve the problem of geckodriver closing the app after choosing an option from the menu.

So far, I've found that geckodriver accumulates errors until it crashes the application with the error [NoSuchWindow](https://docs.rs/fantoccini/0.21.0/fantoccini/error/enum.ErrorStatus.html#variant.NoSuchWindow) with the message “Browsing context has been discarded”.

The errors start appearing after some videos start loading, for example, when the user chooses an episode and the video appears or when the user chooses the language for the video and the application goes to the video page, so perhaps the problem is related to the videos.

For now, I've identified these errors:
geckodriver error: `JavaScript error: , line 0: NotAllowedError: The play method is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.`

fantoccini error: `NoSuchWindow, message: "Browsing context has been discarded"`
